### PR TITLE
Sort line chart legends by the latest count

### DIFF
--- a/src/linechart.js
+++ b/src/linechart.js
@@ -5,6 +5,12 @@ import Tooltip from './tooltip'
 import CustomCursorContainer from './custom-cursor-container'
 import {removeHttpFromNames, getDataByDate, getCategories, includeOnly} from './linechart-data'
 
+import {maxBy} from 'lodash'
+
+function getLatest(data) {
+  return maxBy(data, (d) => d.date)
+}
+
 const colors = ['#993366', '#339966', '#666699', '#FF6600', '#0066CC', '#008080',
 '#993300', '#333399', '#800000', '#660066', '#003366', '#FF8080'];
 
@@ -79,6 +85,10 @@ export default class LineChart extends React.Component {
                   y="count"
                 />
    });
+
+    categories.sort((a, b) => {
+      return getLatest(b.data).count - getLatest(a.data).count
+    })
 
     return (
       <div ref={el => this.container = el}>


### PR DESCRIPTION
This sorts the legend entries in the line chart so that they are in the same order that the lines are in on the right side (latest data) in the chart.